### PR TITLE
Bug 2,3,4

### DIFF
--- a/apps/quick-learn-backend/src/common/constants/email-subject.ts
+++ b/apps/quick-learn-backend/src/common/constants/email-subject.ts
@@ -1,5 +1,5 @@
 export const emailSubjects = {
-  welcome: 'Welcome to Quick Learn!',
-  resetPassword: 'Quick Learn | Reset Password',
-  resetPasswordSuccess: 'Quick Learn | Password Reset Successful',
+  welcome: 'Welcome!',
+  resetPassword: 'Reset Password',
+  resetPasswordSuccess: 'Password Reset Successful',
 };

--- a/apps/quick-learn-backend/src/common/modules/email/email.service.ts
+++ b/apps/quick-learn-backend/src/common/modules/email/email.service.ts
@@ -39,7 +39,7 @@ export class EmailService {
     const emailText = data.body;
     const emailBody = await this.compileMjmlTemplate(emailText);
     try {
-      await this.emailService.send({ ...data, body: emailBody });
+      await this.emailService.send({ ...data, body: emailBody, subject: 'Quick Learn: ' });
     } catch (err) {
       this.logger.error('Something went wrong./n', JSON.stringify(err));
     }

--- a/apps/quick-learn-backend/src/routes/auth/dto/resetpassword.dto.ts
+++ b/apps/quick-learn-backend/src/routes/auth/dto/resetpassword.dto.ts
@@ -13,10 +13,10 @@ export class ResetPasswordDto {
   resetToken: string;
 
   @ApiProperty({ example: 'password' })
-  @IsNotEmpty()
+  @IsNotEmpty({message:"Password should not be empty"})
   @IsString()
   @MinLength(8)
-  @MaxLength(15)
+  @MaxLength(32,{message:"Password must be less than 32 character"})
   @IsStrongPassword({
     minLength: 8,
     minLowercase: 1,

--- a/apps/quick-learn-backend/src/routes/users/dto/create-user.dto.ts
+++ b/apps/quick-learn-backend/src/routes/users/dto/create-user.dto.ts
@@ -21,7 +21,7 @@ export class CreateUserDto {
   first_name: string;
 
   @ApiProperty({ example: 'Doe' })
-  @IsNotEmpty()
+  @IsNotEmpty({message:"Password should not be empty"})
   @IsString()
   @MaxLength(50)
   last_name: string;
@@ -34,10 +34,10 @@ export class CreateUserDto {
   email: string;
 
   @ApiProperty({ example: 'password' })
-  @IsNotEmpty()
+  @IsNotEmpty({message:"Password should not be empty"})
   @IsString()
   @MinLength(8)
-  @MaxLength(15)
+  @MaxLength(32,{message:"Password must be less than 32 character"})
   @IsStrongPassword({
     minLength: 8,
     minLowercase: 1,

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/content/[roadmap]/[course]/[lesson]/lesson.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/content/[roadmap]/[course]/[lesson]/lesson.tsx
@@ -68,7 +68,7 @@ const Lesson = () => {
     };
   }, [setHideNavbar]);
 
-  const [isEditing, setIsEditing] = useState<boolean>(true);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
   const [lesson, setLesson] = useState<TLesson>();
   const [roadmap, setRoadmap] = useState<TRoadmap>();
   const [loading, setLoading] = useState<boolean>(false);


### PR DESCRIPTION
Email Prefix Quick Learn:
newPassword error message text is wrong
Password limit increase to 32 chars.
already created lesson should open in view mode first until changed to edit mode exclusively.