### PR TITLE
Fix: LEARN-61 typos across the application

### DIFF
--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/AddCourseCategory.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/AddCourseCategory.cy.ts
@@ -37,7 +37,7 @@ describe('Primary Skill Update', () => {
     addCourse.AddCourseCategoryWithMoreLimit();
     addCourse
       .getErrorMessage()
-      .should('contain', 'The value should not exceed 30 character.');
+      .should('contain', 'The value should not exceed 30 characters.');
   });
 
   it('Verify Super admin able to edit Courses Categories', () => {

--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/AddCourseCategory.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/AddCourseCategory.cy.ts
@@ -37,7 +37,7 @@ describe('Primary Skill Update', () => {
     addCourse.AddCourseCategoryWithMoreLimit();
     addCourse
       .getErrorMessage()
-      .should('contain', 'The value should not exceed 30 character');
+      .should('contain', 'The value should not exceed 30 character.');
   });
 
   it('Verify Super admin able to edit Courses Categories', () => {

--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/addRoadmap.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/addRoadmap.cy.ts
@@ -38,7 +38,7 @@ describe('Primary Skill Update', () => {
     AddRoadMaps.AddRoadMapCategoriesWithMoreLimit();
     AddRoadMaps.getErrorMessage().should(
       'contain',
-      'The value should not exceed 30 character',
+      'The value should not exceed 30 character.',
     );
   });
   it('Verify Super admin able to edit Roadmap Categories', () => {

--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/addRoadmap.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/addRoadmap.cy.ts
@@ -38,7 +38,7 @@ describe('Primary Skill Update', () => {
     AddRoadMaps.AddRoadMapCategoriesWithMoreLimit();
     AddRoadMaps.getErrorMessage().should(
       'contain',
-      'The value should not exceed 30 character.',
+      'The value should not exceed 30 characters.',
     );
   });
   it('Verify Super admin able to edit Roadmap Categories', () => {

--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/addSkills.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/addSkills.cy.ts
@@ -39,7 +39,7 @@ describe('Primary Skill Update', () => {
     addSkill.AddPrimarySkillWithMoreCharacters();
     addSkill
       .getErrorMessage()
-      .should('contain', 'The value should not exceed 30 character.');
+      .should('contain', 'The value should not exceed 30 characters.');
   });
 
   it('Verify Super admin able to edit Skill', () => {

--- a/apps/quick-learn-frontend-e2e/src/cypress/e2e/addSkills.cy.ts
+++ b/apps/quick-learn-frontend-e2e/src/cypress/e2e/addSkills.cy.ts
@@ -39,7 +39,7 @@ describe('Primary Skill Update', () => {
     addSkill.AddPrimarySkillWithMoreCharacters();
     addSkill
       .getErrorMessage()
-      .should('contain', 'The value should not exceed 30 character');
+      .should('contain', 'The value should not exceed 30 character.');
   });
 
   it('Verify Super admin able to edit Skill', () => {

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/Accountsettings.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/Accountsettings.tsx
@@ -26,7 +26,7 @@ const AccountSettingSechema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(30, 'The value should not exceed 30 character')
+    .max(30, 'The value should not exceed 30 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     })

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/BaseLayout.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/BaseLayout.tsx
@@ -35,7 +35,7 @@ const addSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(30, 'The value should not exceed 30 character')
+    .max(30, 'The value should not exceed 30 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     })
@@ -49,7 +49,7 @@ const editSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(30, 'The value should not exceed 30 character')
+    .max(30, 'The value should not exceed 30 character.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     })

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/BaseLayout.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/account-settings/BaseLayout.tsx
@@ -49,7 +49,7 @@ const editSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(30, 'The value should not exceed 30 character.')
+    .max(30, 'The value should not exceed 30 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     })

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/teams/edit/[member]/formSchema.ts
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/teams/edit/[member]/formSchema.ts
@@ -9,7 +9,7 @@ const baseSchema = {
     })
     .trim()
     .min(1, { message: en.common.fieldRequired })
-    .max(30, { message: 'The value should not exceed 30 character' })
+    .max(30, { message: 'The value should not exceed 30 character.' })
     .refine(onlyAlphabeticValidation, {
       message: 'First name should only contain alphabetic characters',
     }),
@@ -19,7 +19,7 @@ const baseSchema = {
     })
     .trim()
     .min(1, { message: en.common.fieldRequired })
-    .max(30, { message: 'The value should not exceed 30 character' })
+    .max(30, { message: 'The value should not exceed 30 character.' })
     .refine(onlyAlphabeticValidation, {
       message: 'Last name should only contain alphabetic characters',
     }),

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/teams/edit/[member]/formSchema.ts
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/teams/edit/[member]/formSchema.ts
@@ -9,7 +9,7 @@ const baseSchema = {
     })
     .trim()
     .min(1, { message: en.common.fieldRequired })
-    .max(30, { message: 'The value should not exceed 30 character.' })
+    .max(30, { message: 'The value should not exceed 30 characters.' })
     .refine(onlyAlphabeticValidation, {
       message: 'First name should only contain alphabetic characters',
     }),
@@ -19,7 +19,7 @@ const baseSchema = {
     })
     .trim()
     .min(1, { message: en.common.fieldRequired })
-    .max(30, { message: 'The value should not exceed 30 character.' })
+    .max(30, { message: 'The value should not exceed 30 characters.' })
     .refine(onlyAlphabeticValidation, {
       message: 'Last name should only contain alphabetic characters',
     }),

--- a/apps/quick-learn-frontend/src/constants/lang/en.ts
+++ b/apps/quick-learn-frontend/src/constants/lang/en.ts
@@ -212,7 +212,7 @@ export const en = {
   courseCategories: {
     heading: 'Courses Categories',
     subHeading:
-      'Courses can belong to a category. A category could be a way to group learning courses. For example, a you can create a learning course from a book, a blog, a video, for a software application or for any onboarding needs.',
+      'Courses can belong to a category. A category could be a way to group learning courses. For example, you can create a learning course from a book, a blog, a video, for a software application or for any onboarding needs.',
     inputlabel: 'Add new course category',
     inputPlaceHolder: 'Engineering',
     tableName: 'Category name',

--- a/apps/quick-learn-frontend/src/constants/lang/en.ts
+++ b/apps/quick-learn-frontend/src/constants/lang/en.ts
@@ -450,7 +450,7 @@ export const en = {
   },
 
   Search: {
-    default_text: 'Enter atleast 3 character to search',
+    default_text: 'Enter atleast 3 characters to search',
     no_search_result_found: 'No Lessons, Courses, or Roadmaps found',
     Loading: 'Loading....',
   },

--- a/apps/quick-learn-frontend/src/shared/components/AutoResizingTextArea.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/AutoResizingTextArea.tsx
@@ -45,7 +45,7 @@ const AutoResizingTextarea = ({
       ref={textareaRef}
       value={value}
       onChange={handleChange}
-      className={`w-full text-3xl md:text-5xl font-bold text-center border-none overflow-hidden resize-none focus:outline-none min-h-[2.5rem] md:min-h-[3.5rem] transition-all ${
+      className={`w-full capitalize text-3xl md:text-5xl font-bold text-center border-none overflow-hidden resize-none focus:outline-none min-h-[2.5rem] md:min-h-[3.5rem] transition-all ${
         !isEditing ? 'focus:ring-0' : ''
       } ${className}`}
       placeholder={placeholder}

--- a/apps/quick-learn-frontend/src/shared/components/Card.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/Card.tsx
@@ -68,7 +68,7 @@ const Card: FC<CardProps> = ({
           {title}
         </h1>
         <p
-          className={`font-normal text-gray-500 ${
+          className={`font-normal text-gray-500 capitalize ${
             isLongTitle ? 'line-clamp-1' : 'line-clamp-2'
           } text-sm whitespace-pre-line`}
           dangerouslySetInnerHTML={{

--- a/apps/quick-learn-frontend/src/shared/components/NavbarSearchBox.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/NavbarSearchBox.tsx
@@ -277,7 +277,6 @@ const NavbarSearchBox: React.FC<NavbarSearchBoxProps> = ({ isMember }) => {
               <div className="text-center text-gray-500 p-2">
                 {/* add a loading skeleton */}
                 <SearchSkeleton />
-                {/* {en.Search.Loading} */}
               </div>
             ) : hasNoResults ? (
               <div className="text-center text-gray-500 p-2 text-sm">

--- a/apps/quick-learn-frontend/src/shared/components/ProgressCard.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/ProgressCard.tsx
@@ -53,7 +53,7 @@ const ProgressCard = forwardRef<HTMLAnchorElement, ProgressCardProps>(
               {name}
             </h3>
             <p
-              className="font-normal text-sm text-gray-500 line-clamp-3 mt-2"
+              className="font-normal capitalize text-sm text-gray-500 line-clamp-3 mt-2"
               dangerouslySetInnerHTML={{
                 __html: title,
               }}

--- a/apps/quick-learn-frontend/src/shared/modals/addEditCourseModal.tsx
+++ b/apps/quick-learn-frontend/src/shared/modals/addEditCourseModal.tsx
@@ -25,7 +25,7 @@ const AddEditCourseSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(50, 'The value should not exceed 50 character')
+    .max(50, 'The value should not exceed 50 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     }),
@@ -33,7 +33,7 @@ const AddEditCourseSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(5000, 'The value should not exceed 5000 character')
+    .max(5000, 'The value should not exceed 5000 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     }),

--- a/apps/quick-learn-frontend/src/shared/modals/addEditRoadMapModal.tsx
+++ b/apps/quick-learn-frontend/src/shared/modals/addEditRoadMapModal.tsx
@@ -25,7 +25,7 @@ const AddEditRoadmapSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(50, 'The value should not exceed 50 character')
+    .max(50, 'The value should not exceed 50 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     }),
@@ -33,7 +33,7 @@ const AddEditRoadmapSchema = z.object({
     .string()
     .trim()
     .min(1, 'This field is mandatory')
-    .max(5000, 'The value should not exceed 5000 character')
+    .max(5000, 'The value should not exceed 5000 characters.')
     .refine((value) => value.trim().length > 0, {
       message: 'This field is mandatory and cannot contain only whitespace',
     }),


### PR DESCRIPTION
## This PR includes Fixes for Typos across the application.
- [x] 1.Capitalise content>Lesson.tsx title
- [x] 2.Removed an extra a from course category
- [x] 3.While creating a Roadmap/Course/Lesson updated typo character to characters
- [x] 4.While creating a Roadmap and Course, the First alphabet under the description textbox should be in caps.
- [x]  5.Corrected typos throughout for The value should not exceed 30 character to characters.
- [x]  6,7. Corrected typos throughout for The value should not exceed 30 character to characters
