### PR TITLE
fix: LEARN-62 

### DIFF
--- a/apps/quick-learn-backend/src/routes/roadmap-category/roadmap-category.service.ts
+++ b/apps/quick-learn-backend/src/routes/roadmap-category/roadmap-category.service.ts
@@ -80,8 +80,12 @@ export class RoadmapCategoryService extends BasicCrudService<RoadmapCategoryEnti
   async getRoadmapCatergoriesWithRoadmap() {
     return await this.repository
       .createQueryBuilder('category')
-      .leftJoinAndSelect('category.roadmaps', 'roadmaps')
-      .where('roadmaps.archived = :archived', { archived: false })
+      .leftJoinAndSelect(
+        'category.roadmaps',
+        'roadmaps',
+        'roadmaps.archived = :archived',
+        { archived: false },
+      )
       .orderBy('category.name', 'ASC')
       .addOrderBy('category.created_at', 'DESC')
       .getMany();

--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/content/contentRepository.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/content/contentRepository.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import {
   createRoadmap,
-  getContentRepositoryMetadata,
   getRoadmaps,
 } from '@src/apiServices/contentRepositoryService';
 import { en } from '@src/constants/lang/en';
@@ -20,26 +19,23 @@ import {
 import ContentRepositorySkeleton from './ContentRepositorySkeleton';
 import EmptyState from '@src/shared/components/EmptyStatePlaceholder';
 import { useAppDispatch, useAppSelector } from '@src/store/hooks';
-import { updateContentRepository } from '@src/store/features/metadataSlice';
 import {
   addRoadmap,
   selectAllCourses,
   selectAllRoadmaps,
   selectIsRoadmapsInitialized,
-  selectRoadmapsStatus,
 } from '@src/store/features/roadmapsSlice';
+import { useFetchContentRepositoryMetadata } from '@src/context/contextHelperService';
 
 const ContentRepository = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const roadmaps = useAppSelector(selectAllRoadmaps);
   const courses = useAppSelector(selectAllCourses);
-  const roadmapsStatus = useAppSelector(selectRoadmapsStatus);
   const isRoadmapsInitialized = useAppSelector(selectIsRoadmapsInitialized);
   const [openAddModal, setOpenAddModal] = useState(false);
   const [isModalLoading, setIsModalLoading] = useState(false);
-
-  const isLoading = !isRoadmapsInitialized && roadmapsStatus === 'loading';
+  const [isLoading, setIsLoading] = useState(!isRoadmapsInitialized);
 
   const fetchRoadmapData = async () => {
     try {
@@ -56,14 +52,7 @@ const ContentRepository = () => {
     }
   };
 
-  const fetchContentRepositoryMetadata = async () => {
-    try {
-      const res = await getContentRepositoryMetadata();
-      dispatch(updateContentRepository(res.data)); //update redux store metadata
-    } catch (error) {
-      console.error(error);
-    }
-  };
+  const fetchContentRepositoryMetadata = useFetchContentRepositoryMetadata();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -76,6 +65,7 @@ const ContentRepository = () => {
         // Log the error to the console for debugging
         console.error('Error fetching roadmaps and metadata:', err);
       }
+      setIsLoading(false);
     };
 
     fetchData();

--- a/apps/quick-learn-frontend/src/context/contextHelperService.ts
+++ b/apps/quick-learn-frontend/src/context/contextHelperService.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { getContentRepositoryMetadata } from '@src/apiServices/contentRepositoryService';
+import { updateContentRepository } from '@src/store/features/metadataSlice';
+import { UserTypeIdEnum } from 'lib/shared/src';
+import { usePathname } from 'next/navigation';
+import { useAppDispatch } from '@src/store/hooks';
+import { RouteEnum } from '@src/constants/route.enum';
+import { showApiErrorInToast } from '@src/utils/toastUtils';
+
+// Custom hook to fetch content repository metadata
+// This will fetch data for the user other than member or when it is forced
+// to fetch the metadata
+export const useFetchContentRepositoryMetadata = (forceFetch = false) => {
+  const dispatch = useAppDispatch();
+  const path = usePathname();
+
+  const fetchMetadata = async (user_type = UserTypeIdEnum.MEMBER) => {
+    if (
+      !forceFetch &&
+      (path === RouteEnum.CONTENT || user_type === UserTypeIdEnum.MEMBER)
+    ) {
+      return;
+    }
+
+    getContentRepositoryMetadata()
+      .then((res) => {
+        dispatch(updateContentRepository(res.data));
+      })
+      .catch((err) => showApiErrorInToast(err));
+  };
+  return fetchMetadata;
+};

--- a/apps/quick-learn-frontend/src/context/userContext.tsx
+++ b/apps/quick-learn-frontend/src/context/userContext.tsx
@@ -3,6 +3,7 @@ import { getUser } from '@src/apiServices/authService';
 import { TUser } from '@src/shared/types/userTypes';
 import { showApiErrorInToast } from '@src/utils/toastUtils';
 import { createContext, useState, useEffect, useMemo } from 'react';
+import { useFetchContentRepositoryMetadata } from './contextHelperService';
 
 export const UserContext = createContext<{
   user: TUser | null;
@@ -16,13 +17,16 @@ export const UserContext = createContext<{
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<TUser | null>(null);
+  const fetchMetadata = useFetchContentRepositoryMetadata();
 
   useEffect(() => {
     getUser()
       .then((res) => {
         setUser(res.data);
+        fetchMetadata(res.data.user_type_id);
       })
       .catch((err) => showApiErrorInToast(err));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const value = useMemo(

--- a/apps/quick-learn-frontend/src/store/store.ts
+++ b/apps/quick-learn-frontend/src/store/store.ts
@@ -33,6 +33,11 @@ const userProgressPersistConfig = {
   storage,
 };
 
+const metadataPersistConfig = {
+  key: 'metadata',
+  storage,
+};
+
 // Create persisted reducers for the slices you want to persist
 const persistedDashboardReducer = persistReducer(
   dashboardPersistConfig,
@@ -43,9 +48,14 @@ const persistedUserProgressReducer = persistReducer(
   userProgressReducer,
 );
 
+const persistedMetadataReducer = persistReducer(
+  metadataPersistConfig,
+  metadataReducer,
+);
+
 export const store = configureStore({
   reducer: {
-    metadata: metadataReducer,
+    metadata: persistedMetadataReducer, //persisted
     dashboard: persistedDashboardReducer, // persisted
     roadmaps: roadmapsReducer,
     ui: uiReducer,


### PR DESCRIPTION
Metadata persists even when reloaded and fixed the issue category without the roadmap not being shown. (#287)

* Metadata is persisted
* refactored categories not showing
* fixed multiple requests on the content page when the page refresh
* separated the logic from the user context
* added contextApiService file which has separated logic
* refactor: simplify content repository metadata fetching logic