### PR TITLE
Fix: flag lesson count

### DIFF
--- a/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/flagged/flaggedList.tsx
+++ b/apps/quick-learn-frontend/src/app/(Dashboard)/dashboard/flagged/flaggedList.tsx
@@ -38,7 +38,7 @@ const FlaggedList = () => {
     if (!isLoading) {
       dispatch(
         updateSystemPreferencesData({
-          flagged_lessons: flaggedLessons?.length ?? 0,
+          flagged_lessons: totalLessons,
         }),
       );
     }


### PR DESCRIPTION
Update flagged lessons count to use totalLessons instead of flaggedLessons length

## PR Checklist

- [ ] I have reviewed the pull request myself
- [ ] I have tested the feature myself manually
- [ ] I have updated JIRA
- [ ] I have added the description to PR which tells the reviewer what this PR is all about
- [ ] I have made good commit messages
- [ ] I am not mixing two different types of work in one PR. (Do not mix two different features into one PR, or refactoring and feature into one PR)