### PR TITLE
Hotfix: Added text styling in the react quill

### DIFF
--- a/apps/quick-learn-frontend/src/app/(Public)/daily-lesson/[token]/DailyLessonDetail.tsx
+++ b/apps/quick-learn-frontend/src/app/(Public)/daily-lesson/[token]/DailyLessonDetail.tsx
@@ -155,7 +155,7 @@ function DailyLessonDetail() {
         <div className="w-full flex align-middle justify-center">
           <p className="bg-green-100 p-5 rounded-md text-[#166534] flex justify-center items-center gap-2 my-5 mx-2 w-full lg:w-1/2 text-start">
             <span className="text-[#166534] flex bg-white rounded-full w-5 h-5 aspect-square font-bold items-center justify-center">
-              <InformationCircleIcon fontWeight="" />
+              <InformationCircleIcon />
             </span>
             <p>
               <span className="font-bold">
@@ -176,7 +176,7 @@ function DailyLessonDetail() {
     }
 
     return (
-      <div className="flex justify-center items-center gap-2 mb-12 mt-12">
+      <div className="flex justify-center items-center gap-2 mb-12 mt-0 md:mt-6">
         <input
           type="checkbox"
           checked={isChecked}
@@ -225,7 +225,7 @@ function DailyLessonDetail() {
     }
 
     return (
-      <div className="flex justify-center items-center mb-12 mt-6 ml-4">
+      <div className="flex justify-center items-center my-5 mx-2">
         {renderFlaggedBy()}
       </div>
     );
@@ -251,7 +251,7 @@ function DailyLessonDetail() {
   if (!lessonDetails) return <FullPageLoader />;
 
   return (
-    <div className="max-w-screen-2xl mx-auto mt-12 py-3 px-4 sm:py-5 lg:px-8">
+    <div className="max-w-screen-2xl mx-auto mt-12 py-3 mb-12 sm:py-5 md:mb-0">
       <ViewLesson
         lesson={lessonDetails}
         links={link}

--- a/apps/quick-learn-frontend/src/app/global.css
+++ b/apps/quick-learn-frontend/src/app/global.css
@@ -2,7 +2,7 @@
 @import '../../../../node_modules/tailwindcss/components.css';
 @import '../../../../node_modules/tailwindcss/utilities.css';
 
-@import 'react-quill-new/dist/quill.snow.css';
+@import '~react-quill-new/dist/quill.snow.css';
 
 div[role='dialog'] {
   align-content: center !important;

--- a/apps/quick-learn-frontend/src/shared/components/Editor.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/Editor.tsx
@@ -1,12 +1,17 @@
 'use client';
 import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
-import ReactQuill from 'react-quill-new';
+import dynamic from 'next/dynamic';
+import type ReactQuillType from 'react-quill-new';
 
 // All the import which is used for the customisation of the editor
 import EditorToolbar, { formats } from './EditorToolbar';
 import { en } from '@src/constants/lang/en';
 import { fileUploadApiCall } from '@src/apiServices/fileUploadService';
 import { showErrorMessage } from '@src/utils/helpers';
+
+const ReactQuill = dynamic(() => import('react-quill-new'), {
+  ssr: false,
+});
 
 function checkSize(file: File): boolean {
   if (file.size > 1024 * 1024 * 5) {
@@ -35,7 +40,7 @@ const Editor: FC<Props> = ({
   isUpdating = false,
   isAdd = false,
 }) => {
-  const quillRef = useRef<ReactQuill | null>(null);
+  const quillRef = useRef<ReactQuillType>(null);
 
   const handleImageUpload = async (file: File) => {
     if (!checkSize(file)) return;
@@ -140,6 +145,7 @@ const Editor: FC<Props> = ({
       />
       <div className="flex-grow relative">
         <ReactQuill
+          // @ts-expect-error - As forwardRef is not supported in react 19 and we have to wait for the next version of react-quill
           ref={quillRef}
           value={value}
           onChange={setValue}

--- a/apps/quick-learn-frontend/src/shared/components/EditorToolbar.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/EditorToolbar.tsx
@@ -13,6 +13,8 @@ export const formats = [
   'image',
   'code-block',
   'indent',
+  'underline',
+  'strike',
 ];
 
 interface Props {
@@ -115,6 +117,8 @@ const EditorToolbar: FC<Props> = ({
           <button type="button" className="ql-link" />
           <button type="button" className="ql-list" value="bullet" />
           <button type="button" className="ql-list" value="ordered" />
+          <button type="button" className="ql-strike" />
+          <button type="button" className="ql-underline" />
           <button type="button" className="ql-image" />
         </span>
       </div>

--- a/apps/quick-learn-frontend/src/shared/components/ViewLesson.tsx
+++ b/apps/quick-learn-frontend/src/shared/components/ViewLesson.tsx
@@ -9,7 +9,11 @@ import { en } from '@src/constants/lang/en';
 import { TLesson } from '../types/contentRepository';
 import { TBreadcrumb } from '../types/breadcrumbType';
 import { FlagIcon } from '@heroicons/react/24/outline';
-import ReactQuill from 'react-quill-new';
+import dynamic from 'next/dynamic';
+
+const ReactQuill = dynamic(() => import('react-quill-new'), {
+  ssr: false,
+});
 
 // Separate components for better performance
 const LessonHeader = memo(
@@ -24,7 +28,7 @@ const LessonHeader = memo(
     createdAt?: string | Date;
     showCreatedBy?: boolean;
   }) => (
-    <div className="px-4 mb-8 text-center sm:px-6 lg:px-8">
+    <div className="px-4 mb-4 text-center sm:px-6 md:mb-8 lg:px-8">
       <div className="items-baseline">
         <h1 className="text-3xl md:text-5xl font-extrabold leading-tight first-letter:uppercase">
           {name}
@@ -52,7 +56,7 @@ const LessonContent = memo(({ content }: { content: string }) => {
   };
 
   return (
-    <article className="flex mx-auto w-full max-w-5xl format format-sm sm:format-base lg:format-lg format-blue px-8 md:px-10 py-4 mb-8">
+    <article className="flex mx-auto w-full max-w-5xl format format-sm format-blue px-4 pt-0 pb-4 mb-4 sm:format-base md:px-10 md:pt-4 md:mb-8 lg:format-lg">
       <div className="quill-content-display w-full">
         <ReactQuill
           value={content}


### PR DESCRIPTION
This PR includes hotfixes for the following things:
- update layout and styling in DailyLessonDetail, Editor, and ViewLesson components; 
- improve dynamic import for ReactQuill
- Added the text styling on the editor