### PR TITLE
Chore: Tokens clean up

### DIFF
--- a/apps/quick-learn-backend/src/common/modules/session/session.service.ts
+++ b/apps/quick-learn-backend/src/common/modules/session/session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BasicCrudService } from '@src/common/services';
 import { SessionEntity } from '@src/entities/session.entity';
@@ -6,10 +6,25 @@ import { Repository } from 'typeorm';
 
 @Injectable()
 export class SessionService extends BasicCrudService<SessionEntity> {
+  private readonly logger = new Logger(SessionService.name);
   constructor(
     @InjectRepository(SessionEntity)
     repo: Repository<SessionEntity>,
   ) {
     super(repo);
+  }
+
+  async deleteAllExpiredSessions() {
+    // We're here delete all the expire token and we are typecase as the column was varchar.
+    this.logger.log(
+      `------------- Deleting all the data which has expired. -------------`,
+    );
+    const { affected } = await this.repository
+      .createQueryBuilder('session')
+      .delete()
+      .where("expires ~ '^[0-9]+$'")
+      .andWhere('TO_TIMESTAMP(CAST(expires AS bigint) / 1000) < NOW()')
+      .execute();
+    this.logger.log(`------------- Deleted ${affected} rows. -------------`);
   }
 }

--- a/apps/quick-learn-backend/src/routes/auth/auth.service.ts
+++ b/apps/quick-learn-backend/src/routes/auth/auth.service.ts
@@ -99,16 +99,14 @@ export class AuthService {
 
     const hash = Helpers.generateRandomhash();
 
-    const refreshTokenExpires = ms(
-      loginDto.rememberMe
-        ? this.refreshTokenRememberMeExpiresIn
-        : this.refreshTokenExpiresIn,
-    );
+    const expiresIn = loginDto.rememberMe
+      ? this.refreshTokenRememberMeExpiresIn
+      : this.refreshTokenExpiresIn;
 
     const session = await this.sessionService.create({
       user,
       hash,
-      expires: `${Date.now() + refreshTokenExpires}`,
+      expires: `${Date.now() + expiresIn}`,
     });
 
     return await this.getTokensData({

--- a/apps/quick-learn-backend/src/routes/cronjob/cronjob.module.ts
+++ b/apps/quick-learn-backend/src/routes/cronjob/cronjob.module.ts
@@ -4,14 +4,19 @@ import { UsersModule } from '../users/users.module';
 import { LessonProgressModule } from '../lesson-progress/lesson-progress.module';
 import { CronjobController } from './cronjob.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { EmailModule, LessonTokenModule } from '@src/common/modules';
+import {
+  EmailModule,
+  LessonTokenModule,
+  SessionModule,
+} from '@src/common/modules';
 import { LeaderboardEntity } from '@src/entities/leaderboard.entity';
 import { LeaderboardCronService } from './leaderboard-cron.service';
 import { LeaderboardModule } from '../leaderboard/leaderboard.module';
 import { AuthModule } from '../auth/auth.module';
 import { QuarterlyLeaderboardEntity } from '@src/entities';
+import { TokenCleanupService } from './token-cleanup.service';
+
 @Module({
-  // TODO: Remove lesson token repository from here to use module
   imports: [
     TypeOrmModule.forFeature([LeaderboardEntity, QuarterlyLeaderboardEntity]),
     UsersModule,
@@ -20,8 +25,9 @@ import { QuarterlyLeaderboardEntity } from '@src/entities';
     LeaderboardModule,
     LessonTokenModule,
     AuthModule,
+    SessionModule,
   ],
-  providers: [LessonEmailService, LeaderboardCronService],
+  providers: [TokenCleanupService, LessonEmailService, LeaderboardCronService],
   controllers: [CronjobController],
 })
 export class CronjobModule {}

--- a/apps/quick-learn-backend/src/routes/cronjob/token-cleanup.service.ts
+++ b/apps/quick-learn-backend/src/routes/cronjob/token-cleanup.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { LessThan } from 'typeorm';
+import { subMonths } from 'date-fns';
+import { SessionService } from '@src/common/modules/session/session.service';
+import { ResetTokenService } from '../auth/reset-token.service';
+import { LessonTokenService } from '@src/common/modules/lesson-token/lesson-token.service';
+import { LessonProgressService } from '../lesson-progress/lesson-progress.service';
+import { TIMEZONE } from '@quick-learn/shared';
+
+@Injectable()
+export class TokenCleanupService {
+  private readonly logger = new Logger(TokenCleanupService.name);
+  private readonly DELETE_LAST_X_MONTH_LESSON_PROGRESS = 6;
+  constructor(
+    private readonly sessionService: SessionService,
+    private readonly resetTokenService: ResetTokenService,
+    private readonly lessonTokenService: LessonTokenService,
+    private readonly userLessonProgress: LessonProgressService,
+  ) {}
+
+  // This will clean up user-lesson-progress and it's token of prior to last 6 month.
+  // This will run at 12:00 AM, on day 1 of the month, only in June and December
+  @Cron('0 0 1 6,12 *', {
+    timeZone: TIMEZONE,
+  })
+  async cleanUserLessonProgress() {
+    const beforeXMonth = subMonths(
+      new Date(),
+      this.DELETE_LAST_X_MONTH_LESSON_PROGRESS,
+    );
+    this.logger.log(
+      `------------- Deleting all the data which is before: ${beforeXMonth} -------------`,
+    );
+
+    this.logger.log(`------------- Deleting all lesson tokens -------------`);
+    const { affected: deletedLessonToken } =
+      await this.lessonTokenService.delete({
+        expires_at: LessThan(beforeXMonth),
+      });
+    this.logger.log(
+      `------------- Deleted ${deletedLessonToken} lesson tokens -------------`,
+    );
+
+    this.logger.log(`------------- Deleting all user progress -------------`);
+    const { affected: deletedUserProgress } =
+      await this.userLessonProgress.delete({
+        completed_date: LessThan(beforeXMonth),
+      });
+    this.logger.log(
+      `------------- Deleted ${deletedUserProgress}  user progress -------------`,
+    );
+
+    this.logger.log(
+      `------------- Deleting all the data which is before ${beforeXMonth} completed -------------`,
+    );
+  }
+
+  // This will delete all the expired reset tokens
+  // This will run every week At 12:00 AM, only on Sunday
+  @Cron('0 0 * * SUN', {
+    timeZone: TIMEZONE,
+  })
+  async cleanResetToken() {
+    // We're here delete all the expire token
+    this.logger.log(
+      `------------- Deleting all the data which has expired. -------------`,
+    );
+    const { affected } = await this.resetTokenService.delete({
+      expiry_date: LessThan(new Date()),
+    });
+    this.logger.log(`------------- Deleted ${affected} rows. -------------`);
+  }
+
+  // This will delete all the expired session tokens
+  // This will run every week At 1:00 AM, only on Sunday
+  @Cron('0 1 * * SUN', {
+    timeZone: TIMEZONE,
+  })
+  async cleanSessionToken() {
+    this.sessionService.deleteAllExpiredSessions();
+  }
+}


### PR DESCRIPTION
This PR includes the clean-up task for which cronjobs are added:
1. The reset token will be cleaned up every Sunday.
2. Session tokens will be cleaned up every Sunday.
3. The daily lesson token and user progress will be cleaned up every six months.
Suppose this will run at 12:00 AM, on day 1 of the month, only in June and December but it will cleanup the token before December so we have 6 months of data.