### PR TITLE
Add cascading delete for user foreign key in leaderboard entities

### DIFF
--- a/apps/quick-learn-backend/src/database/migrations/1743071424724-migration.ts
+++ b/apps/quick-learn-backend/src/database/migrations/1743071424724-migration.ts
@@ -1,0 +1,67 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export class Migration1743071424724 implements MigrationInterface {
+  private readonly tables = ['leaderboard', 'quarterly_leaderboard'];
+  private readonly foriegnKeyColumn = 'user_id';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.runMigration(queryRunner);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.runMigration(queryRunner);
+  }
+
+  private async runMigration(queryRunner: QueryRunner) {
+    for (const tableName of this.tables) {
+      const table = await this.getTable(queryRunner, tableName);
+      if (!table) continue;
+
+      const foreignKey = this.getForeignKey(table, this.foriegnKeyColumn);
+      if (foreignKey) {
+        await this.dropForeignKey(queryRunner, tableName, foreignKey);
+        await this.createForeignKey(
+          queryRunner,
+          tableName,
+          new TableForeignKey({
+            columnNames: [this.foriegnKeyColumn],
+            referencedColumnNames: ['id'],
+            referencedTableName: 'user',
+            onDelete: 'CASCADE',
+          }),
+        );
+      }
+    }
+  }
+
+  private async getTable(queryRunner: QueryRunner, tableName: string) {
+    return queryRunner.getTable(tableName);
+  }
+
+  private getForeignKey(table: Table, oldColumnName: string) {
+    return table.foreignKeys.find((fk) =>
+      fk.columnNames.includes(oldColumnName),
+    );
+  }
+
+  private async dropForeignKey(
+    queryRunner: QueryRunner,
+    tableName: string,
+    foreignKey: TableForeignKey,
+  ) {
+    await queryRunner.dropForeignKey(tableName, foreignKey);
+  }
+
+  private async createForeignKey(
+    queryRunner: QueryRunner,
+    tableName: string,
+    foreignKey: TableForeignKey,
+  ) {
+    await queryRunner.createForeignKey(tableName, foreignKey);
+  }
+}

--- a/apps/quick-learn-backend/src/entities/leaderboard.entity.ts
+++ b/apps/quick-learn-backend/src/entities/leaderboard.entity.ts
@@ -37,7 +37,7 @@ export class LeaderboardEntity {
   })
   created_at: Date;
 
-  @ManyToOne(() => UserEntity)
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 

--- a/apps/quick-learn-backend/src/entities/quarterly-leaderboard.entity.ts
+++ b/apps/quick-learn-backend/src/entities/quarterly-leaderboard.entity.ts
@@ -44,7 +44,7 @@ export class QuarterlyLeaderboardEntity {
   })
   created_at: Date;
 
-  @ManyToOne(() => UserEntity)
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 


### PR DESCRIPTION
Implement cascading delete behavior for the user foreign key in the leaderboard and quarterly leaderboard entities. This change ensures that when a user is deleted, associated leaderboard entries are also removed. A migration script is included to update the database schema accordingly.